### PR TITLE
Add: node disconnect(true) - Ability to remove node from main class to stop reconnection

### DIFF
--- a/src/lib/LavaShark.ts
+++ b/src/lib/LavaShark.ts
@@ -256,6 +256,20 @@ export default class LavaShark extends EventEmitter {
     }
 
     /**
+     * Stop the reconnection check of the node
+     * @param {string} nodeIdentifier - The identifier of the node
+     */
+    public stopCheckNodeState(nodeIdentifier: string) {
+        this.nodes = this.nodes.filter(node => node.identifier !== nodeIdentifier);
+
+        if (this.nodes.length === 0 && this.#checkNodesStateTimer) {
+            clearInterval(this.#checkNodesStateTimer);
+            this.#checkNodesStateTimer = undefined;
+            this.emit('debug', 'Stopped checking node states because there are no connected nodes left');
+        }
+    }
+
+    /**
      * Creates a new player or returns an existing one
      * @param {object} options - The player options
      * @param {string} options.guildId - The guild id that player belongs to

--- a/src/lib/Node.ts
+++ b/src/lib/Node.ts
@@ -226,8 +226,10 @@ export default class Node {
 
     /**
      * Disconnect from node
+     * @param {boolean} full - Fully disconnect the node. Removes it from the nodes list and stops the periodic reconnection
      */
-    public disconnect() {
+    public disconnect(full: boolean = false) {
+        if (full && this.#lavashark) this.#lavashark.stopCheckNodeState(this.identifier);
         if (this.#ws !== null) this.#ws.close(1000, 'LavaShark: disconnect');
     }
 

--- a/typings/src/lib/LavaShark.d.ts
+++ b/typings/src/lib/LavaShark.d.ts
@@ -81,6 +81,11 @@ export default class LavaShark extends EventEmitter {
      */
     private keepCheckNodesState;
     /**
+     * Stop the reconnection check of the node
+     * @param {string} nodeIdentifier - The identifier of the node
+     */
+    public stopCheckNodeState(nodeIdentifier: string): void;
+    /**
      * Creates a new player or returns an existing one
      * @param {object} options - The player options
      * @param {string} options.guildId - The guild id that player belongs to

--- a/typings/src/lib/Node.d.ts
+++ b/typings/src/lib/Node.d.ts
@@ -42,8 +42,9 @@ export default class Node {
     connect(): void;
     /**
      * Disconnect from node
+     * @param {boolean} full - Fully disconnect the node. Removes it from the nodes list and stops the periodic reconnection
      */
-    disconnect(): void;
+    disconnect(full?: boolean): void;
     /**
      * Reconnects the node
      */


### PR DESCRIPTION
This PR allows you to use the a new 'full' option for `node.disconnect();` so that it fully disconnects.

Currently, when you use `node.disconnect();`, it closes the node connection, but within 5 minutes your node gets reconnected due to the `keepCheckNodesState` scheduler as this.nodes in `LavaShark.ts` does not get updated.

With these changes - when using `node.disconnect(true);` it updates the node array (this.node) in the LavaShark class and if it becomes empty, it stops the scheduler entirely.  